### PR TITLE
Use os.path.join to join paths in safe way

### DIFF
--- a/extract-kindle-clippings.py
+++ b/extract-kindle-clippings.py
@@ -38,7 +38,7 @@ else:
 
 if not os.path.isfile(infile):
     username = getpass.getuser()
-    infile = '/media/' + username + '/Kindle/documents/My Clippings.txt'
+    infile = os.path.join('/media', username, 'Kindle', 'documents/My Clippings.txt')
     if not os.path.isfile(infile):
         print('Could not find "My Clippings.txt", please provide the file location as an argument\nUsage: ' + argv[0] + ' <clippings file> [<output directory>]\n')
 
@@ -207,7 +207,7 @@ for key in pub_title.keys():
     else:
         continue            # Skip to next title if there are no new hashes
 
-    outfile = outpath + getvalidfilename(fname)
+    outfile = os.path.join(outpath, getvalidfilename(fname))
 
     newfile = os.path.isfile(outfile)
 


### PR DESCRIPTION
Fixes an error when the script's second argument lacks a trailing slash.

```
python kindle-clippings-to-obsidian/extract-kindle-clippings.py "/Volumes/Kindle/documents/My Clippings.txt" ~/Downloads/clippings
```
Output:
```
Adding new note to /Users/kamil/Downloads/clippingsEmezi Akwaeke - Pet.rst: 4a2cb9e0 Your  2020-02-20 09:54:41
```
I.e. instead of a file inside `~/Downloads/clippings` it created a file with `clippings` as a prefix :)