### PR TITLE
Add ability to export only selected books

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,21 @@ First, make the script executable:
 
 Then, run the script, including both the past of your txt document and an output directory:
 
-`./extract-kindle-clippings.py [<path to My Clippings.txt file>] [<output directory>]`
+`./extract-kindle-clippings.py [<path to My Clippings.txt file>] -o [<output directory>]`
 
 Example:
 
-`./extract-kindle-clippings.py /Users/dannberg/Desktop/Temp/My\ Clippings.txt /Users/dannberg/Desktop/Temp/clippings/`
+`./extract-kindle-clippings.py /Users/dannberg/Desktop/Temp/My\ Clippings.txt -o /Users/dannberg/Desktop/Temp/clippings/`
 
-If either the input file or output directory is not specified, the default input file is `./My Clippings.txt` or `/media/$USER/Kindle/documents/My Clippings.txt`. The default output directory is `./clippings/`.
+If either the input file is not specified, the default input file is `./My Clippings.txt` or `/media/$USER/Kindle/documents/My Clippings.txt`.
+
+If an output flag and directory is not specified, the default output directory is `clippings/` in the current directory. If `clippings/` does not exist, it will be created.
+
+After running the script, you'll be presented with a list of all books found in your clippings file. You can:
+- Enter `0` to process all books
+- Enter a single number to process one specific book
+- Enter multiple numbers separated by spaces to process several books
+- If `0` is included with other numbers, all books will be processed
 
 4. Navigate to the new `clippings` directory, open the text file of the book you want, and copy/paste into Obsidian.
 
@@ -71,9 +79,9 @@ This script requires Python 3 and is written for use on Linux, Mac, BSD and othe
 
 # How it works
 
-The script works by scanning `My Clippings.txt` and generating a SHA-256 hash for each note, which is stored in the output file comments. When the script is run, it scans all RST-files in the output directory for hashes, and only writes the notes and highlights which weren't found in the output directory. Publications which have only one or two notes/highlights don't get their own output file, but the notes/highlights are appended to `short_notes.rst`, together with the author and title of the publication. Each output file is given the time and date of the most recent note/highlight.
+The script works by scanning `My Clippings.txt` and generating a SHA-256 hash for each note, which is stored in the output file comments. When the script is run, it scans all Markdown files in the output directory for hashes, and only writes the notes and highlights which weren't found in the output directory. Publications which have only one or two notes/highlights don't get their own output file, but the notes/highlights are appended to `short_notes.md`, together with the author and title of the publication. Each output file is given the time and date of the most recent note/highlight.
 
-Because the script only scans the hashes in the comments, you're free to rename, move, split, combine, amend and otherwise edit the output files, as long as you keep the comment lines (the lines starting with `..`), keep the files within the output directory (or subdirectories thereof) and keep the `.rst` file extension. You can move comment lines anywhere in the RST-file, and even safely delete or change the actual notes/highlights. You can also safely combine output files from different e-readers or other sources.
+Because the script only scans the hashes in the comments, you're free to rename, move, split, combine, amend and otherwise edit the output files, as long as you keep the comment lines (the lines starting with `..`), keep the files within the output directory (or subdirectories thereof) and keep the `.md` file extension. You can move comment lines anywhere in the RST-file, and even safely delete or change the actual notes/highlights. You can also safely combine output files from different e-readers or other sources.
 
 # My other Obsidian & Productivity Systems
 

--- a/extract-kindle-clippings.py
+++ b/extract-kindle-clippings.py
@@ -185,7 +185,50 @@ while line:
 
 mc.close()
 
+def get_user_book_selection(titles):
+    # Create a sorted list of unique titles
+    unique_titles = sorted(list(set(titles.values())))
+    
+    print("\nSelect a book (or books) to output:")
+    print("[0]: All books")
+    for i, title in enumerate(unique_titles, 1):
+        print(f"[{i}]: {title}")
+    
+    while True:
+        try:
+            selection = input("\nInput one or more numbers, separated by a space: ").strip()
+            numbers = [int(num) for num in selection.split()]
+            
+            # Validate input
+            if not numbers:
+                print("Please enter at least one number")
+                continue
+                
+            # Check if 0 is selected
+            if 0 in numbers:
+                return unique_titles
+                
+            # Validate range of numbers
+            if any(num < 0 or num > len(unique_titles) for num in numbers):
+                print(f"Please enter numbers between 0 and {len(unique_titles)}")
+                continue
+                
+            # Return selected titles
+            return [unique_titles[num-1] for num in numbers]
+            
+        except ValueError:
+            print("Please enter valid numbers separated by spaces")
+            continue
+
+# Get user selection
+selected_titles = get_user_book_selection(pub_title)
+
+# Modify the main processing loop to only process selected books
 for key in pub_title.keys():
+    # Skip if this book wasn't selected
+    if pub_title[key] not in selected_titles:
+        continue
+        
     nr_notes = len(pub_notes[key])
     author = pub_author[key]
     title = pub_title[key]

--- a/extract-kindle-clippings.py
+++ b/extract-kindle-clippings.py
@@ -30,33 +30,38 @@ import os
 from datetime import datetime, timedelta, timezone
 import getpass
 import sys
+import argparse
 
-if len(sys.argv) > 1:
-    infile = sys.argv[1]
-else:
-    infile = 'My Clippings.txt'
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description='Extract and organize highlights and notes from Kindle "My Clippings.txt" file'
+    )
+    parser.add_argument('input_file', nargs='?', default='My Clippings.txt',
+                      help='Path to My Clippings.txt file (default: My Clippings.txt)')
+    parser.add_argument('-o', '--output', default='.',
+                      help='Output directory (default: current directory)')
+    return parser.parse_args()
 
+args = parse_args()
+infile = args.input_file
+outpath = args.output
+
+# Check if input file exists
 if not os.path.isfile(infile):
     username = getpass.getuser()
     infile = os.path.join('/media', username, 'Kindle', 'documents/My Clippings.txt')
     if not os.path.isfile(infile):
-        print('Could not find "My Clippings.txt", please provide the file location as an argument\nUsage: ' + sys.argv[0] + ' <clippings file> [<output directory>]\n')
+        print('Could not find "My Clippings.txt", please provide the file location as an argument')
+        sys.exit(1)
 
-if len(sys.argv) > 2:
-    outpath = sys.argv[2]
-else:
-    outpath = 'clippings/'
-
+# Create output directory if it doesn't exist
 if not os.path.isdir(outpath):
-    # Create output path if it doesn't exist
     os.makedirs(outpath, exist_ok=True)
-
 
 def getvalidfilename(filename):
     import unicodedata
     clean = unicodedata.normalize('NFKD', filename)
     return re.sub('[^\w\s()\'.?!:-]', '', clean)
-
 
 note_sep = '=========='
 
@@ -69,7 +74,6 @@ regex_page = re.compile('Page ([\d\-]+)')
 regex_date = re.compile('Added on\s+(.+)$')
 
 regex_hashline = re.compile('^\.\.\s*([a-fA-F0-9]+)' + '\s*')
-
 
 pub_title = {}
 pub_author = {}


### PR DESCRIPTION
After running the script, a user will be presented with a list of available books for export, and will be able to choose one or more (or all) books to export.

Additionally, the output directory is now optional and takes a flag (`-o`).