### PR TITLE
Added processing for Spanish Kindle OS

### DIFF
--- a/languages/es.json
+++ b/languages/es.json
@@ -1,0 +1,5 @@
+{
+    "Added on": "Añadido el",
+    "Loc": "posición",
+    "Page": "página"
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-dateutil


### PR DESCRIPTION
Hi, I’ve just added support for processing the 'My Clippings.txt' file generated by the Spanish version of Kindle OS. This solution can be easily extended to accommodate additional languages and is completely transparent to English-speaking users.